### PR TITLE
feat: add image pickers with expo-image-picker

### DIFF
--- a/fashion-try-on/App.tsx
+++ b/fashion-try-on/App.tsx
@@ -6,6 +6,7 @@ import HomeScreen from './src/screens/HomeScreen';
 import SettingsScreen from './src/screens/SettingsScreen';
 import DetailsScreen from './src/screens/DetailsScreen';
 import { RootStackParamList, RootTabParamList } from './src/navigation/types';
+import { ImageProvider } from './src/context/ImageContext';
 
 const Stack = createNativeStackNavigator<RootStackParamList>();
 const Tab = createBottomTabNavigator<RootTabParamList>();
@@ -21,11 +22,13 @@ function Tabs() {
 
 export default function App() {
   return (
-    <NavigationContainer>
-      <Stack.Navigator>
-        <Stack.Screen name="Tabs" component={Tabs} options={{ headerShown: false }} />
-        <Stack.Screen name="Details" component={DetailsScreen} />
-      </Stack.Navigator>
-    </NavigationContainer>
+    <ImageProvider>
+      <NavigationContainer>
+        <Stack.Navigator>
+          <Stack.Screen name="Tabs" component={Tabs} options={{ headerShown: false }} />
+          <Stack.Screen name="Details" component={DetailsScreen} />
+        </Stack.Navigator>
+      </NavigationContainer>
+    </ImageProvider>
   );
 }

--- a/fashion-try-on/package-lock.json
+++ b/fashion-try-on/package-lock.json
@@ -15,6 +15,7 @@
         "expo": "~53.0.22",
         "expo-blur": "~14.1.5",
         "expo-image-manipulator": "~13.1.7",
+        "expo-image-picker": "~15.0.7",
         "expo-status-bar": "~2.2.3",
         "react": "19.0.0",
         "react-native": "0.79.6",
@@ -5711,6 +5712,27 @@
       "dependencies": {
         "expo-image-loader": "~5.1.0"
       },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-picker": {
+      "version": "15.0.7",
+      "resolved": "https://registry.npmjs.org/expo-image-picker/-/expo-image-picker-15.0.7.tgz",
+      "integrity": "sha512-u8qiPZNfDb+ap6PJ8pq2iTO7JKX+ikAUQ0K0c7gXGliKLxoXgDdDmXxz9/6QdICTshJBJlBvI0MwY5NWu7A/uw==",
+      "license": "MIT",
+      "dependencies": {
+        "expo-image-loader": "~4.7.0"
+      },
+      "peerDependencies": {
+        "expo": "*"
+      }
+    },
+    "node_modules/expo-image-picker/node_modules/expo-image-loader": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/expo-image-loader/-/expo-image-loader-4.7.0.tgz",
+      "integrity": "sha512-cx+MxxsAMGl9AiWnQUzrkJMJH4eNOGlu7XkLGnAXSJrRoIiciGaKqzeaD326IyCTV+Z1fXvIliSgNW+DscvD8g==",
+      "license": "MIT",
       "peerDependencies": {
         "expo": "*"
       }

--- a/fashion-try-on/package.json
+++ b/fashion-try-on/package.json
@@ -18,6 +18,7 @@
     "expo": "~53.0.22",
     "expo-blur": "~14.1.5",
     "expo-image-manipulator": "~13.1.7",
+    "expo-image-picker": "~15.0.7",
     "expo-status-bar": "~2.2.3",
     "react": "19.0.0",
     "react-native": "0.79.6",

--- a/fashion-try-on/src/components/ClothingImagePicker.tsx
+++ b/fashion-try-on/src/components/ClothingImagePicker.tsx
@@ -1,0 +1,53 @@
+import { Button, Image, View, StyleSheet } from 'react-native';
+import * as ImagePicker from 'expo-image-picker';
+import { useImageContext } from '../context/ImageContext';
+
+export default function ClothingImagePicker() {
+  const { clothingImage, setClothingImage } = useImageContext();
+
+  const pickImage = async (fromCamera: boolean) => {
+    const permission = fromCamera
+      ? await ImagePicker.requestCameraPermissionsAsync()
+      : await ImagePicker.requestMediaLibraryPermissionsAsync();
+
+    if (!permission.granted) {
+      alert('Permission required');
+      return;
+    }
+
+    const result = fromCamera
+      ? await ImagePicker.launchCameraAsync({ mediaTypes: ImagePicker.MediaTypeOptions.Images, quality: 0.5 })
+      : await ImagePicker.launchImageLibraryAsync({ mediaTypes: ImagePicker.MediaTypeOptions.Images, quality: 0.5 });
+
+    if (!result.canceled && result.assets && result.assets.length > 0) {
+      setClothingImage(result.assets[0].uri);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      {clothingImage && <Image source={{ uri: clothingImage }} style={styles.image} />}
+      <Button
+        title={clothingImage ? 'Change Clothing Image' : 'Pick Clothing Image'}
+        onPress={() => pickImage(false)}
+      />
+      <View style={styles.spacer} />
+      <Button title="Use Camera" onPress={() => pickImage(true)} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    marginVertical: 10,
+  },
+  image: {
+    width: 100,
+    height: 100,
+    marginBottom: 10,
+  },
+  spacer: {
+    height: 10,
+  },
+});

--- a/fashion-try-on/src/components/ModelImagePicker.tsx
+++ b/fashion-try-on/src/components/ModelImagePicker.tsx
@@ -1,0 +1,50 @@
+import { Button, Image, View, StyleSheet } from 'react-native';
+import * as ImagePicker from 'expo-image-picker';
+import { useImageContext } from '../context/ImageContext';
+
+export default function ModelImagePicker() {
+  const { modelImage, setModelImage } = useImageContext();
+
+  const pickImage = async (fromCamera: boolean) => {
+    const permission = fromCamera
+      ? await ImagePicker.requestCameraPermissionsAsync()
+      : await ImagePicker.requestMediaLibraryPermissionsAsync();
+
+    if (!permission.granted) {
+      alert('Permission required');
+      return;
+    }
+
+    const result = fromCamera
+      ? await ImagePicker.launchCameraAsync({ mediaTypes: ImagePicker.MediaTypeOptions.Images, quality: 0.5 })
+      : await ImagePicker.launchImageLibraryAsync({ mediaTypes: ImagePicker.MediaTypeOptions.Images, quality: 0.5 });
+
+    if (!result.canceled && result.assets && result.assets.length > 0) {
+      setModelImage(result.assets[0].uri);
+    }
+  };
+
+  return (
+    <View style={styles.container}>
+      {modelImage && <Image source={{ uri: modelImage }} style={styles.image} />}
+      <Button title={modelImage ? 'Change Model Image' : 'Pick Model Image'} onPress={() => pickImage(false)} />
+      <View style={styles.spacer} />
+      <Button title="Use Camera" onPress={() => pickImage(true)} />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: 'center',
+    marginVertical: 10,
+  },
+  image: {
+    width: 100,
+    height: 100,
+    marginBottom: 10,
+  },
+  spacer: {
+    height: 10,
+  },
+});

--- a/fashion-try-on/src/context/ImageContext.tsx
+++ b/fashion-try-on/src/context/ImageContext.tsx
@@ -1,0 +1,29 @@
+import React, { createContext, useContext, useState, ReactNode } from 'react';
+
+export type ImageContextType = {
+  modelImage: string | null;
+  clothingImage: string | null;
+  setModelImage: (uri: string | null) => void;
+  setClothingImage: (uri: string | null) => void;
+};
+
+const ImageContext = createContext<ImageContextType | undefined>(undefined);
+
+export function ImageProvider({ children }: { children: ReactNode }) {
+  const [modelImage, setModelImage] = useState<string | null>(null);
+  const [clothingImage, setClothingImage] = useState<string | null>(null);
+
+  return (
+    <ImageContext.Provider value={{ modelImage, setModelImage, clothingImage, setClothingImage }}>
+      {children}
+    </ImageContext.Provider>
+  );
+}
+
+export function useImageContext() {
+  const context = useContext(ImageContext);
+  if (!context) {
+    throw new Error('useImageContext must be used within an ImageProvider');
+  }
+  return context;
+}

--- a/fashion-try-on/src/screens/HomeScreen.tsx
+++ b/fashion-try-on/src/screens/HomeScreen.tsx
@@ -1,10 +1,13 @@
-import { View, Text, Button, StyleSheet } from 'react-native';
+import { View, Button, StyleSheet } from 'react-native';
 import { RootTabScreenProps } from '../navigation/types';
+import ModelImagePicker from '../components/ModelImagePicker';
+import ClothingImagePicker from '../components/ClothingImagePicker';
 
 export default function HomeScreen({ navigation }: RootTabScreenProps<'Home'>) {
   return (
     <View style={styles.container}>
-      <Text>Home Screen</Text>
+      <ModelImagePicker />
+      <ClothingImagePicker />
       <Button title="Go to Details" onPress={() => navigation.navigate('Details')} />
     </View>
   );
@@ -15,5 +18,6 @@ const styles = StyleSheet.create({
     flex: 1,
     alignItems: 'center',
     justifyContent: 'center',
+    padding: 16,
   },
 });


### PR DESCRIPTION
## Summary
- integrate expo-image-picker for camera and gallery access
- create model and clothing image pickers storing URIs in context
- show thumbnails and allow re-selection

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b4d86507748328a7fc20e9bd319b9c